### PR TITLE
fix buefy css asset path

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -5,7 +5,7 @@ import { ipcRenderer } from 'electron';
 import App from './App';
 import router from './router';
 import Buefy from 'buefy';
-import 'buefy/lib/buefy.css';
+import 'buefy/dist/buefy.css';
 
 Vue.use(Buefy);
 


### PR DESCRIPTION
In the latest version they changed the path name from `lib` to `dist` 
https://buefy.org/documentation/start/

and Thanks for the example